### PR TITLE
if use_express was false it was ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function InsteonLocalPlatform(log, config, api) {
     self.model = config["model"]
     self.devices = config["devices"]
     self.server_port = config["server_port"] || 3000
-    self.use_express = config["use_express"] || true    
+    self.use_express = config.hasOwnProperty("use_express") ? config["use_express"] : true    
     self.keepAlive = config["keepAlive"] || 3600
     self.checkInterval = config["checkInterval"] || 20
 	


### PR DESCRIPTION
I noticed use_express was being ignored, this is because the || true check was always winning if the value was false.  So adding a hasOwnProperty check so that only if the value is populated do we return it.