### PR TITLE
Controller/Responder Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Devices are also defined in the config.json as follows:
   - `dimmable`:  dimmable or non-dimming device - valid values are "yes" or "no"
   - `deviceType`:  valid values include 'lightbulb', 'dimmer', 'switch', 'scene', 'remote', 'iolinc', 'motionsensor', 'leaksensor', 'outlet', and 'fan'.
   - `refresh`:  device-level refresh interval in seconds.  This will override the platform-level refresh value and will still refresh individual devices even if platform-level polling is turned off.
+  - `controllers`: this is an array `["<Insteon ID>","<Insteon ID>"]` of other Insteon devices that this device is controlled by. ie if you have a plug in dimmer that is controlled by a wall switch you would add the wall switch ID as a controller for the plug in dimmer. The controller device does not need to be a device listed in the config.json
 
 **Scene config changes in 0.3.2 and later**
 

--- a/config-example.json
+++ b/config-example.json
@@ -22,7 +22,9 @@
 									"name": "Great Room Lamp",
 								  	"deviceID" : "<Insteon ID>",
 								  	"dimmable" : "yes",
-								  	"deviceType" : "lightbulb" },
+								  	"deviceType" : "lightbulb"
+								  	"controllers" : ["<Insteon ID>","<Insteon ID>"]
+								},
 								{
 									"name": "FR Lamp",
 									"deviceID": "<Insteon ID>",

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var accessories = []
 var connectedToHub = false
 var connectingToHub = false
 var connectionCount = 0
+var inUse = true
 var express_init = false
 var eventListener_init = false
 
@@ -41,12 +42,18 @@ function InsteonLocalPlatform(log, config, api) {
     self.pass = config["pass"]
     self.model = config["model"]
     self.devices = config["devices"]
-    self.refreshInterval = config["refresh"] || 0
-    self.server_port = config["server_port"]
-    self.use_express = config["use_express"] || true    
+    self.server_port = config["server_port"] || 3000
+    self.use_express = config.hasOwnProperty("use_express") ? config["use_express"] : true    
     self.keepAlive = config["keepAlive"] || 3600
+    self.checkInterval = config["checkInterval"] || 20
 	
-    var config = {
+	if (self.model == "2242") {
+		self.refreshInterval = config["refresh"] || 300
+	} else {
+		self.refreshInterval = config["refresh"] || 0
+	}
+	
+    self.hubConfig = {
         host: self.host,
         port: self.port,
         user: self.user,
@@ -54,27 +61,51 @@ function InsteonLocalPlatform(log, config, api) {
     }
 
     app.get('/light/:id/on', function(req, res) {
-        var id = req.params.id
+        var id = req.params.id.toUpperCase()
         hub.light(id).turnOn().then(function(status) {
             if (status.response) {
                 res.sendStatus(200)
+                
+				var isDevice = _.contains(self.deviceIDs, id, 0)
+			
+				if (isDevice) {
+					var foundDevice = accessories.filter(function(item) {
+						return item.id == id
+					})
+				}
+			
+				foundDevice = foundDevice[0]
+				setTimeout(function(){foundDevice.getStatus.call(foundDevice)},1000)
+				
             } else {
                 res.sendStatus(404)
             }
         })
     })
-
+	
     app.get('/light/:id/off', function(req, res) {
-        var id = req.params.id
+        var id = req.params.id.toUpperCase()
         hub.light(id).turnOff().then(function(status) {
             if (status.response) {
                 res.sendStatus(200)
+                
+				var isDevice = _.contains(self.deviceIDs, id, 0)
+			
+				if (isDevice) {
+					var foundDevice = accessories.filter(function(item) {
+						return item.id == id
+					})
+				}
+			
+				foundDevice = foundDevice[0]
+				foundDevice.getStatus.call(foundDevice)
+                
             } else {
                 res.sendStatus(404)
             }
         })
     })
-
+	
     app.get('/light/:id/status', function(req, res) {
         var id = req.params.id
         hub.light(id).level(function(err, level) {
@@ -91,6 +122,18 @@ function InsteonLocalPlatform(log, config, api) {
         hub.light(id).level(targetLevel).then(function(status) {
             if (status.response) {
                 res.sendStatus(200)
+                
+                var isDevice = _.contains(self.deviceIDs, id, 0)
+			
+				if (isDevice) {
+					var foundDevice = accessories.filter(function(item) {
+						return item.id == id
+					})
+				}
+			
+				foundDevice = foundDevice[0]
+				foundDevice.getStatus.call(foundDevice)
+                
             } else {
                 res.sendStatus(404)
             }
@@ -105,6 +148,18 @@ function InsteonLocalPlatform(log, config, api) {
             } 
             if (status.completed) {
                 res.sendStatus(200)
+                
+                var isDevice = _.contains(self.deviceIDs, id, 0)
+			
+				if (isDevice) {
+					var foundDevice = accessories.filter(function(item) {
+						return item.id == id
+					})
+				}
+			
+				foundDevice = foundDevice[0]
+                foundDevice.getSceneState.call(foundDevice)	
+                
             } else {
                 res.sendStatus(404)
             }
@@ -119,6 +174,18 @@ function InsteonLocalPlatform(log, config, api) {
             } 
             if (status.completed) {
                 res.sendStatus(200)
+                
+                var isDevice = _.contains(self.deviceIDs, id, 0)
+			
+				if (isDevice) {
+					var foundDevice = accessories.filter(function(item) {
+						return item.id == id
+					})
+				}
+			
+				foundDevice = foundDevice[0]
+                foundDevice.getSceneState.call(foundDevice)	
+                
             } else {
                 res.sendStatus(404)
             }
@@ -150,6 +217,21 @@ function InsteonLocalPlatform(log, config, api) {
         hub.ioLinc(id).relayOn().then(function(status) {
             if (status.response) {
                 res.sendStatus(200)
+                
+                var isDevice = _.contains(self.deviceIDs, id, 0)
+			
+				if (isDevice) {
+					var foundDevice = accessories.filter(function(item) {
+						return item.id == id
+					})
+				}
+			
+				foundDevice = foundDevice[0]
+                
+				setTimeout(function() {
+					foundDevice.getSensorStatus.call(foundDevice)
+				}, 1000 * foundDevice.gdo_delay)
+				
             } else {
                 res.sendStatus(404)
             }
@@ -161,6 +243,21 @@ function InsteonLocalPlatform(log, config, api) {
         hub.ioLinc(id).relayOff().then(function(status) {
             if (status.response) {
                 res.sendStatus(200)
+                
+                var isDevice = _.contains(self.deviceIDs, id, 0)
+			
+				if (isDevice) {
+					var foundDevice = accessories.filter(function(item) {
+						return item.id == id
+					})
+				}
+			
+				foundDevice = foundDevice[0]
+                
+				setTimeout(function() {
+					foundDevice.getSensorStatus.call(foundDevice)
+				}, 1000 * foundDevice.gdo_delay)
+                
             } else {
                 res.sendStatus(404)
             }
@@ -187,25 +284,67 @@ function InsteonLocalPlatform(log, config, api) {
         self.deviceIDs.push(self.devices[i].deviceID)
     }
 	
-	connectToHub()
-	connectionWatcher()
+	self.connectToHub()
 	
-	function connectToHub(){
+	if (self.keepAlive > 0){
+		connectionWatcher()
+	}
+    
+    function connectionWatcher() { //resets connection to hub every keepAlive mS
+		self.log('Started connection watcher...')
+		
+		if (self.model == "2245") {
+			if(self.keepAlive > 0){
+				setInterval(function(){
+					self.log('Closing connection to Hub...')
+					hub.close()
+					connectedToHub = false
+					
+					self.log.debug('Connected: ' + connectedToHub + ', Connecting: ' + connectingToHub)
+					
+					setTimeout(function () { //wait 5 sec to reconnect to Hub
+						self.log('Reconnecting to Hub...')
+						self.connectToHub()
+					}, 5000)
+					
+				},1000*self.keepAlive)
+			}
+    	}
+    	
+    	if (self.model == "2242") { //check every 10 sec to see if a request is in progress
+			setInterval(function(){
+				if (typeof hub.status == 'undefined' && connectedToHub == true) { //undefined if no request in progress
+					inUse = false
+					self.log('Closing connection to Hub...')
+					hub.close()
+					connectedToHub = false
+				} else {
+					inUse = true
+				}
+			}, 1000*self.checkInterval) 	
+    	}
+    }
+}
+
+InsteonLocalPlatform.prototype.connectToHub = function (){
+		var self = this
+		
 		if (self.model == "2245") {
 			self.log.debug('Connecting to Insteon Model 2245 Hub...')
 			connectingToHub = true
-			hub.httpClient(config, function(had_error) {
+			hub.httpClient(self.hubConfig, function(had_error) {
 				self.log('Connected to Insteon Model 2245 Hub...')
 				hub.emit('connect')
 				connectedToHub = true
 				connectingToHub = false
 				if(eventListener_init == false) {
-					eventListener()
+					self.eventListener()
 				}
 
 				if(self.use_express && express_init == false){
 					express_init = true
 					app.listen(self.server_port)
+					self.log('Started Insteon Express server...')
 				}
 			})
 		} else if (self.model == "2243") {
@@ -216,135 +355,249 @@ function InsteonLocalPlatform(log, config, api) {
 				connectedToHub = true
 				connectingToHub = false
 				if(eventListener_init == false) {
-					eventListener()
+					self.eventListener()
 				}
 
 				if(self.use_express && express_init == false){
 					express_init = true
 					app.listen(self.server_port)
+					self.log('Started Insteon Express server...')
 				}
 			})
-		} else {
+		} else if (self.model == "2242") {
 			self.log.debug('Connecting to Insteon Model 2242 Hub...')
 			connectingToHub = true
 			hub.connect(self.host, function() {
-				self.log('Connected to Insteon Moden 2242 Hub...')
+				self.log('Connected to Insteon Model 2242 Hub...')
 				hub.emit('connect')
 				connectedToHub = true
 				connectingToHub = false
+				
+				if(self.keepAlive == 0 && eventListener_init == false) {
+					self.eventListener()
+				}				
+				
+				if(self.use_express && express_init == false){
+					express_init = true
+					app.listen(self.server_port)
+					self.log('Started Insteon Express server...')
+				}
+			})
+		} else {
+			self.log.debug('Connecting to Insteon PLM...')
+			connectingToHub = true
+			hub.serial(self.host,{baudRate:19200}, function(had_error) {
+				self.log('Connected to Insteon PLM...')
+				connectedToHub = true
+				connectingToHub = false
 				if(eventListener_init == false) {
-					eventListener()
+					self.eventListener()
 				}
 
 				if(self.use_express && express_init == false){
 					express_init = true
 					app.listen(self.server_port)
+					self.log('Started Insteon Express server...')
 				}
 			})
 		}
 	}
-    
-    function connectionWatcher() { //resets connection to hub every keepAlive mS
-    	if(self.keepAlive > 0){
-    		setTimeout(function(){
-    			//hub.cancelPending()
-    			self.log('Closing connection to Hub...')
-    			hub.close()
-    			connectedToHub = false
-    			connectionWatcher()
-    		},1000*self.keepAlive)
-    		if (connectedToHub == false && connectingToHub != true) {
-    			self.log('Reconnecting to Hub...')
-    			connectToHub()
-    		}
-    	}
-    }
-    
-    function eventListener() {
-        var deviceIDs = platform.deviceIDs
-		eventListener_init = true
-        
-        self.log('Insteon event listener started')
+
+InsteonLocalPlatform.prototype.checkHubConnection = function () {
+	var self = this
+	
+	if(connectingToHub == false) {
+		if(connectedToHub == false) {
+			console.log('Reconnecting to Hub...')
+			self.connectToHub()
+		}
+	}
+	
+	return
+}
+
+InsteonLocalPlatform.prototype.eventListener = function () {
+	var self = this
+	
+	var deviceIDs = self.deviceIDs
+	eventListener_init = true
+	
+	self.log('Insteon event listener started...')
+	
+	hub.on('command', function(data) {
 		
-        hub.on('command', function(data) {
-            if (typeof data.standard !== 'undefined') {
-				var info = JSON.stringify(data)
-				var id = data.standard.id
-				var command1 = data.standard.command1
-				var command2 = data.standard.command2
+		if (typeof data.standard !== 'undefined') {
+			self.log.debug('Received command for ' + data.standard.id)
+			
+			var info = JSON.stringify(data)
+			var id = data.standard.id.toUpperCase()
+			var command1 = data.standard.command1
+			var command2 = data.standard.command2
+			var messageType = data.standard.messageType
+			var gateway = data.standard.gatewayId
+			
+			var isDevice = _.contains(deviceIDs, id, 0)
+			
+			if (isDevice) {
+				var foundDevices = accessories.filter(function(item) {
+					return item.id == id
+				})
 
-				var isDevice = _.contains(deviceIDs, id, 0)
+				self.log.debug('Found ' + foundDevices.length + ' accessories matching ' + id)
+				self.log.debug('Hub command: ' + info)
 
-				self.log.debug("Hub Command: " + info)
+				for (var i = 0, len = foundDevices.length; i < len; i++) {
+					var foundDevice = foundDevices[i]
+					self.log.debug('Got event for ' + foundDevice.name)
+				
+					switch (foundDevice.deviceType) {
+					case 'lightbulb':
+					case 'dimmer':
+					case 'switch':
+						if (command1 == "19" || command1 == "03" || command1 == "04" || command1 == "00" || (command1 == "06" && messageType == "1")) { //19 = status
+							var level_int = parseInt(command2, 16) * (100 / 255)
+							var level = Math.ceil(level_int)
 
-				if (isDevice) {
-					var foundDevices = accessories.filter(function(item) {
-						return item.id == id
-					})
+							self.log('Got updated status for ' + foundDevice.name)
 
-					self.log.debug('Found ' + foundDevices.length + ' accessories matching ' + id)
-					self.log.debug('Hub command: ' + info)
-
-					for (var i = 0, len = foundDevices.length; i < len; i++) {
-						var foundDevice = foundDevices[i]
-						self.log.debug('Got event for ' + foundDevice.name)
-					
-						switch (foundDevice.deviceType) {
-						case 'lightbulb':
-						case 'dimmer':
-						case 'switch':
-							if (command1 == 19 || command1 == 3 || command1 == 0) { //19 = status
-								var level_int = parseInt(command2, 16) * (100 / 255)
-								var level = Math.ceil(level_int)
-
-								self.log('Got updated status for ' + foundDevice.name)
-
-								if (foundDevice.dimmable) {
-									foundDevice.service.getCharacteristic(Characteristic.Brightness).updateValue(level)
-									foundDevice.level = level
-								}
-						
-								if(level > 0){
-									foundDevice.currentState = true
-								} else {
-									foundDevice.currentState = false
-								}
-						
-								foundDevice.service.getCharacteristic(Characteristic.On).updateValue(foundDevice.currentState)
-								foundDevice.lastUpdate = moment()
+							if (foundDevice.dimmable) {
+								foundDevice.service.getCharacteristic(Characteristic.Brightness).updateValue(level)
+								foundDevice.level = level
 							}
 					
-							break
-				
-						case 'scene':
-							self.log('Got updated status for ' + foundDevice.name)
-							foundDevice.getSceneState.call(foundDevice)	
-							foundDevice.lastUpdate = moment()					
-						
-							break
-				
-						case 'iolinc':
-							if (command1 == 11 || command1 == 13) {
-								setTimeout(function() {
-									foundDevice.getSensorStatus.call(foundDevice)
-								}, 1000 * foundDevice.gdo_delay)
+							if(level > 0){
+								foundDevice.currentState = true
+							} else {
+								foundDevice.currentState = false
 							}
-							break
-						
-						case 'fan':
-							self.log('Got updated status for ' + foundDevice.name)
-							if (command1 == 19) {//fan portion of fanlinc
-								foundDevice.getFanState.call(foundDevice)
-							}
-							foundDevice.lastUpdate = moment()					
-							break
-						
+					
+							foundDevice.service.getCharacteristic(Characteristic.On).updateValue(foundDevice.currentState)
+							foundDevice.lastUpdate = moment()
 						}
+						
+						if (command1 == 11) { //11 = on
+							var level_int = parseInt(command2, 16)*(100/255);
+							var level = Math.ceil(level_int);
+			
+							self.log('Got on event for ' + foundDevice.name);
+			
+							if(foundDevice.dimmable){
+								if(messageType == 1){
+									var level_int = parseInt(command2, 16)*(100/255);
+									var level = Math.ceil(level_int);
+									foundDevice.service.getCharacteristic(Characteristic.Brightness).updateValue(level);
+									foundDevice.level = level
+								} else {setTimeout(function(){foundDevice.getStatus.call(foundDevice)},5000)}
+							}
+							
+							foundDevice.service.getCharacteristic(Characteristic.On).updateValue(true);
+							foundDevice.currentState = true
+							foundDevice.lastUpdate = moment()	
+						}
+						
+						if (command1 == 12) { //fast on
+			
+							self.log('Got fast on event for ' + foundDevice.name);
+			
+							if(foundDevice.dimmable){
+								foundDevice.service.getCharacteristic(Characteristic.Brightness).updateValue(100);
+								foundDevice.level = 100
+							}
+							
+							foundDevice.service.getCharacteristic(Characteristic.On).updateValue(true);
+							foundDevice.currentState = true
+							foundDevice.lastUpdate = moment()	
+						}
+						
+						if (command1 == 13 || command1 == 14) { //13 = off, 14= fast off
+							if (command1 == 13) {
+								self.log('Got off event for ' + foundDevice.name);
+							} else {self.log('Got fast off event for ' + foundDevice.name)}
+							
+							if(foundDevice.dimmable){
+								foundDevice.service.getCharacteristic(Characteristic.Brightness).updateValue(0);
+								foundDevice.level = 0
+							}
+							foundDevice.service.getCharacteristic(Characteristic.On).updateValue(false);
+							foundDevice.currentState = false
+							foundDevice.lastUpdate = moment()
+						}
+						
+						if (command1 == 18) { //18 = stop changing
+							self.log('Got stop dimming event for ' + foundDevice.name);
+							foundDevice.getStatus.call(foundDevice)
+						}
+						
+						break
+			
+					case 'scene':
+						self.log('Got updated status for ' + foundDevice.name)
+						
+						foundDevice.getSceneState.call(foundDevice)	
+						foundDevice.lastUpdate = moment()						
+						
+						if (messageType == '3' || (messageType == '6' && command1 !== '06')) {
+							var group = parseInt(command2, 16)
+							var foundGroupID = parseInt(foundDevice.groupID)
+							if (foundGroupID !== group) {
+								self.log('Event not for correct group (group: ' + group + ')')
+								break
+							}
+							
+							if(typeof foundDevice.groupMembers !== 'undefined') {
+								self.log('Getting status of scene members (group: ' + group + ')...')
+								foundDevice.groupMembers.forEach(function(deviceID){
+									var isDefined = _.contains(deviceIDs, deviceID, 0)
+									if(isDefined){
+										var groupDevice = accessories.filter(function(item) {
+											return (item.id == deviceID)
+										})
+										
+										groupDevice = groupDevice[0]
+										self.log('Getting status of scene device ' + groupDevice.name)
+										groupDevice.getStatus.call(groupDevice)
+									}
+								})
+							}
+						}
+						
+						break
+			
+					case 'iolinc':
+						if (command1 == 11 || command1 == 13) {
+							setTimeout(function() {
+								foundDevice.getSensorStatus.call(foundDevice)
+							}, 1000 * foundDevice.gdo_delay)
+						} 
+						break
+					
+					case 'fan':
+						self.log('Got updated status for ' + foundDevice.name)
+						if (command1 == 19) {//fan portion of fanlinc
+							foundDevice.getFanState.call(foundDevice)
+						}
+						foundDevice.lastUpdate = moment()					
+						break
+					
+					case 'remote':
+						self.log('Got updated status for ' + foundDevice.name)
+						if (messageType == 6) {
+							foundDevice.handleRemoteEvent.call(foundDevice, gateway, command1)
+						}
+						foundDevice.lastUpdate = moment()					
+						break
+					
+					case 'outlet':
+						self.log('Got updated status for ' + foundDevice.name)
+						foundDevice.getOutletState.call(foundDevice)
+						foundDevice.lastUpdate = moment()					
+						break
+					
 					}
 				}
-        	}
-        })
-    }
+			}
+		}
+	})
 }
 
 InsteonLocalPlatform.prototype.accessories = function(callback) {
@@ -411,15 +664,17 @@ InsteonLocalAccessory.prototype.pollStatus = function() {
     var now = moment()
     var lastUpdate = self.lastUpdate
     var delta = now.diff(lastUpdate, 'seconds')
-
+	
     if (delta < self.refreshInterval) {
         clearTimeout(self.pollTimer)
         self.pollTimer = setTimeout(function() {
             self.pollStatus.call(self)
         }, 1000 * (self.refreshInterval - delta))
     } else {
-        self.log('Polling status for ' + self.name + '...')
-
+        console.log('Polling status for ' + self.name + '...')
+		
+		self.platform.checkHubConnection()
+		
         switch (self.deviceType) {
         case 'lightbulb':
         case 'dimmer':
@@ -446,6 +701,11 @@ InsteonLocalAccessory.prototype.pollStatus = function() {
             self.getFanState.call(self)
             setTimeout(function() {self.pollStatus.call(self)}, (1000 * self.refreshInterval))
             break
+            
+        case 'outlet':
+            self.getOutletState.call(self)
+            setTimeout(function() {self.pollStatus.call(self)}, (1000 * self.refreshInterval))
+            break    
         } 
     }
 }
@@ -454,62 +714,64 @@ InsteonLocalAccessory.prototype.setPowerState = function(state, callback) {
     var powerOn = state ? "on" : "off"
     var self = this
 	
+	self.platform.checkHubConnection()
+	
     if (state !== self.currentState) {
             self.log("Setting power state of " + self.name + " to " + powerOn)
 			if (state) {
-				self.light.turnOn().then(function(status) {
-					if (status.success) {
-							if (self.dimmable) {
-								self.service.getCharacteristic(Characteristic.Brightness).updateValue(100)
-							}
-							self.level = 100
-							self.service.getCharacteristic(Characteristic.On).updateValue(true)
-							self.currentState = true
-							self.lastUpdate = moment()
-						
-							if (typeof callback !== 'undefined') {
-								callback(null, self.currentState)
-								return
-							} else {
-								return
-							}       
-					} else {
-						self.log("Error setting power state of " + self.name + " to " + powerOn)
-						if (typeof callback !== 'undefined') {
-							callback(error, null)
-							return
-						} else {
-							return
+				setTimeout(function(){self.light.turnOn().then(function(status) {
+					setTimeout(function(){
+						if (status.success) { //if command actually worked, do nothing
+							//do nothing
+						} else { //if command didn't work, check status to see what happened and update homekit
+							self.log("Error setting power state of " + self.name + " to " + powerOn)
+							self.getStatus.call(self)
 						}
-					}
+					},0)
 				})
+				},800)
+				
+				//assume that the command worked and report back to homekit
+				if (self.dimmable) {
+					self.service.getCharacteristic(Characteristic.Brightness).updateValue(100)
+				}
+				self.level = 100
+				self.service.getCharacteristic(Characteristic.On).updateValue(true)
+				self.currentState = true
+				self.lastUpdate = moment()
+			
+				if (typeof callback !== 'undefined') {
+					callback(null, self.currentState)
+					return
+				} else {
+					return
+			}  
 			} else {
-				self.light.turnOff().then(function(status) {
-					if (status.success) {
-							if (self.dimmable) {
-								self.service.getCharacteristic(Characteristic.Brightness).updateValue(0)
-							}
-							self.level = 0
-							self.service.getCharacteristic(Characteristic.On).updateValue(false)
-							self.currentState = false
-							self.lastUpdate = moment()
-						
-							if (typeof callback !== 'undefined') {
-								callback(null, self.currentState)
-								return
-							} else {
-								return
-							}       
-					} else {
-						self.log("Error setting power state of " + self.name + " to " + powerOn)
-						if (typeof callback !== 'undefined') {
-							callback(error, null)
-							return
-						} else {
-							return
+				self.light.turnOff().then(function(status) {					
+					setTimeout(function(){
+						if (status.success) { //if command actually worked, do nothing
+							//do nothing
+						} else { //if command didn't work, check status to see what happened and update homekit
+							self.log("Error setting power state of " + self.name + " to " + powerOn)
+							self.getStatus.call(self)
 						}
-					}
+					},0)
 				})
+				
+				if (self.dimmable) {
+						self.service.getCharacteristic(Characteristic.Brightness).updateValue(0)
+					}
+				self.level = 0
+				self.service.getCharacteristic(Characteristic.On).updateValue(false)
+				self.currentState = false
+				self.lastUpdate = moment()
+				
+				if (typeof callback !== 'undefined') {
+					callback(null, self.currentState)
+					return
+				} else {
+					return
+				}    
 			}           
         } else {
 			self.currentState = state
@@ -527,10 +789,12 @@ InsteonLocalAccessory.prototype.getPowerState = function(callback) {
     var self = this
 	var currentState
 	
+	self.platform.checkHubConnection()
+	
     self.log('Getting power state for ' + self.name)
 
-    self.light.level(function(err,level) {
-		if(err || typeof level == 'undefined'){
+    self.light.level(function(error,level) {
+		if(error || typeof level == 'undefined'){
 			self.log("Error getting power state of " + self.name)
 			if (typeof callback !== 'undefined') {
 				callback(error, null)
@@ -565,40 +829,40 @@ InsteonLocalAccessory.prototype.getPowerState = function(callback) {
 InsteonLocalAccessory.prototype.setBrightnessLevel = function(level, callback) {
     var self = this
 	
-	self.log.debug("Canceling Brightness Command For: " + self.name + self.id)
+	self.platform.checkHubConnection()
+	
     hub.cancelPending(self.id)
     
     self.log("Setting level of " + self.name + " to " + level + '%')
     self.light.level(level).then(function(status)
      {    
-        if (status.success) {                
-            self.level = level
+        self.level = level
             self.service.getCharacteristic(Characteristic.Brightness).updateValue(self.level)
 
-			if (self.level > 0) {
-				self.service.getCharacteristic(Characteristic.On).updateValue(true)
-				self.currentState = true
-			} else if (self.level == 0) {
-				self.service.getCharacteristic(Characteristic.On).updateValue(false)
-				self.currentState = false
-			}
-			
-			self.log.debug(self.name + ' is ' + (self.currentState ? 'on' : 'off') + ' at ' + level + '%')
-			self.lastUpdate = moment()
-			
-			if (typeof callback !== 'undefined') {
-				callback(null, self.level)
+		if (self.level > 0) {
+			self.service.getCharacteristic(Characteristic.On).updateValue(true)
+			self.currentState = true
+		} else if (self.level == 0) {
+			self.service.getCharacteristic(Characteristic.On).updateValue(false)
+			self.currentState = false
+		}
+		
+		self.log.debug(self.name + ' is ' + (self.currentState ? 'on' : 'off') + ' at ' + level + '%')
+		self.lastUpdate = moment()
+		
+		setTimeout(function() {
+			if (status.success) {                
+				//do nothing	
 			} else {
-				return
-			}	
-        } else {
-			self.log("Error setting level of " + self.name)   
-            if (typeof callback !== 'undefined') {
-                callback(error, null)
-                return
-            } else {
-                return
-            }
+				self.log("Error setting level of " + self.name)   
+				self.getStatus.call(self)
+			}
+		},0)
+		
+		if (typeof callback !== 'undefined') {
+			callback(null, self.level)
+		} else {
+			return
 		}
 	})
 }
@@ -606,6 +870,8 @@ InsteonLocalAccessory.prototype.setBrightnessLevel = function(level, callback) {
 InsteonLocalAccessory.prototype.getBrightnessLevel = function(callback) {
     var self = this
 	var currentState
+	
+	self.platform.checkHubConnection()
 	
     self.log('Getting brightness for ' + self.name)
 
@@ -644,6 +910,8 @@ InsteonLocalAccessory.prototype.getStatus = function() {
     var self = this
 	var currentState
 	
+	self.platform.checkHubConnection()
+	
     self.log('Getting status for ' + self.name)
 
     self.light.level(function(err,level) {
@@ -673,10 +941,12 @@ InsteonLocalAccessory.prototype.getStatus = function() {
 InsteonLocalAccessory.prototype.getSensorStatus = function(callback) {
     var self = this
 	
+	self.platform.checkHubConnection()
+	
     self.log('Getting sensor state for ' + self.name)
 
-	self.iolinc.status(function(err,status){
-		if (err || status == null || typeof status == 'undefined') {			
+	self.iolinc.status(function(error,status){
+		if (error || status == null || typeof status == 'undefined' || typeof status.sensor == 'undefined') {			
 			if (typeof callback !== 'undefined') {
                 callback(error, null)
                 return
@@ -703,36 +973,48 @@ InsteonLocalAccessory.prototype.getSensorStatus = function(callback) {
 
 InsteonLocalAccessory.prototype.setRelayState = function(state, callback) {
     var self = this
-    state = 'on'
-
+    //0=open 1=close
+	
+	self.platform.checkHubConnection()
+	
     self.log("Setting " + self.name + " relay to " + state)
+	
+	if (state !== self.currentState){
+		self.iolinc.relayOn().then(function(status){
+			if (status.success) {
+				self.targetState = (self.currentState == 0) ? 1 : 0
+				self.service.getCharacteristic(Characteristic.TargetDoorState).updateValue(self.targetState)
+				self.log('Setting ' + self.name + ' target state to ' + self.targetState)
 
-    self.iolinc.relayOn().then(function(status){
-        if (status.success) {
-            self.targetState = (self.currentState == 0) ? 1 : 0
-            self.service.getCharacteristic(Characteristic.TargetDoorState).updateValue(self.targetState)
-            self.log('Setting ' + self.name + 'target state to ' + self.targetState)
-
-            setTimeout(function() {
-                self.getSensorStatus(function() {
-                    self.lastUpdate = moment()
-                    if (typeof callback !== 'undefined') {
-                        callback(null, self.targetState)
-                    } else {
-                        return
-                    }
-                })
-            }, 1000 * self.gdo_delay)
-        } else {
-        	self.log("Error setting relay state of " + self.name + " to " + state)
-        	if (typeof callback !== 'undefined') {
-                callback(error, null)
-                return
-            } else {
-                return
-            }
-        }     
-    })
+				setTimeout(function() {
+					self.getSensorStatus(function() {
+						self.lastUpdate = moment()
+						if (typeof callback !== 'undefined') {
+							callback(null, self.targetState)
+						} else {
+							return
+						}
+					})
+				}, 1000 * self.gdo_delay)
+			} else {
+				self.log("Error setting relay state of " + self.name + " to " + state)
+				if (typeof callback !== 'undefined') {
+					callback(error, null)
+					return
+				} else {
+					return
+				}
+			}     
+		})
+	} else {
+		self.log(self.name + " is already at commanded state")
+		if (typeof callback !== 'undefined') {
+			callback(null, self.currentState)
+			return
+		} else {
+			return
+		}
+	}    
 }
 
 InsteonLocalAccessory.prototype.setSceneState = function(state, callback) {
@@ -740,10 +1022,11 @@ InsteonLocalAccessory.prototype.setSceneState = function(state, callback) {
     var powerOn = state ? "on" : "off"
     var groupID = parseInt(self.groupID)
 	
+	self.platform.checkHubConnection()
+	
 	self.log("Setting power state of " + self.name + " to " + powerOn)
 	
 	if (state) {
-		self.log.debug('State: ' + util.inspect(state))
 		hub.sceneOn(groupID).then(function(status) {
 			if (status.completed) {
 					self.level = 100
@@ -802,6 +1085,8 @@ InsteonLocalAccessory.prototype.getSceneState = function(callback) {
 	var eight_buttonArray = {'A': 7, 'B': 6, 'C': 5,'D': 4,'E': 3,'F': 2,'G': 1,'H': 0};
 	var six_buttonArray = {'A': 5,'B': 4,'C': 3,'D': 2};
 	
+	self.platform.checkHubConnection()
+	
 	if(self.six_btn == true){
 		buttonArray = six_buttonArray
 	} else {
@@ -824,7 +1109,7 @@ InsteonLocalAccessory.prototype.getSceneState = function(callback) {
 	self.log('Getting status for ' + self.name)
 	
 	hub.directCommand(self.id, cmd, timeout, function(err,status){
-		if(err || status == null || typeof status == 'undefined' || typeof status.response == 'undefined'){
+		if(err || status == null || typeof status == 'undefined' || typeof status.response == 'undefined' || typeof status.response.standard == 'undefined' || status.success == false){
 			self.log("Error getting power state of " + self.name)
 			self.log.debug('Err: ' + util.inspect(err))
 			
@@ -894,10 +1179,12 @@ InsteonLocalAccessory.prototype.getFanState = function(callback) {
     var self = this
 	var currentState
 	
+	self.platform.checkHubConnection()
+	
     self.log('Getting state for ' + self.name)
 
-    self.light.fan(function(err,state) {
-		if(err || typeof state == 'undefined'){
+    self.light.fan(function(error,state) {
+		if(error || typeof state == 'undefined'){
 			self.log("Error getting power state of " + self.name)
 			if (typeof callback !== 'undefined') {
 				callback(error, null)
@@ -951,9 +1238,8 @@ InsteonLocalAccessory.prototype.setFanState = function(level, callback) {
     var self = this
 	var targetLevel
 	
-	self.log("Setting Fan of " + self.name + " to " + level + '%')
+	self.platform.checkHubConnection()
 	
-	self.log.debug("Canceling Fan Command For: " + self.name + self.deviceID)
     hub.cancelPending(self.id)
     
     if (level == 0){
@@ -1034,6 +1320,279 @@ InsteonLocalAccessory.prototype.setFanState = function(level, callback) {
 	})
 }
 
+InsteonLocalAccessory.prototype.handleRemoteEvent = function(group, command) {
+	var self = this
+	var buttonArray = [{group: 1, button: 'B'},{group: 2, button: 'A'},{group: 3, button: 'D'},{group: 4, button: 'C'},{group: 5, button: 'F'},{group: 6, button: 'E'},{group: 7, button: 'H'},{group: 8, button: 'G'}] //button to group number map; documentation is wrong
+	
+	self.platform.checkHubConnection()
+	
+	var buttonName = buttonArray.filter(function(item){			
+		return item.group == group
+	})
+	
+	if (typeof buttonName[0] == 'undefined') {
+		self.log.debug('Button group: ' + group)
+		self.log.debug('Button not from a defined device')
+		return
+	} else {	
+		buttonName = buttonName[0].button
+	}
+	
+	if (buttonName == self.button) {
+		if (self.stateless == true) { //stateless switch
+			self.service.getCharacteristic(Characteristic.ProgrammableSwitchEvent).updateValue(0)
+			self.log.debug(self.name + ' button ' + buttonName + ' was triggered')
+			self.lastUpdate = moment()
+		} else { //regular switch
+			if(command == 11){
+				self.currentState = true
+			} else {
+				self.currentState = false
+			}
+			self.lastUpdate = moment()			
+			self.service.getCharacteristic(Characteristic.On).updateValue(self.currentState)
+			self.log.debug(self.name + ' button ' + buttonName + ' is ' + (self.currentState ? 'on' : 'off'))
+		}
+	}
+	return
+}
+
+InsteonLocalAccessory.prototype.setOutletState = function(state, callback) {
+    var powerOn = state ? "on" : "off"
+    var self = this
+	var cmd
+	var timeout = 0
+	
+	self.platform.checkHubConnection()
+	
+	self.log("Setting power state of " + self.name + " to " + powerOn)
+	
+	if (state) { //state = true = on
+		if(self.position == 'bottom') {	
+			cmd = {
+			  extended: true,
+			  cmd1: '11',
+			  cmd2: 'FF',
+			  userData: ['02'],
+			  isStandardResponse: true
+			}
+		} else {
+			cmd = {
+			  cmd1: '11',
+			  cmd2: 'FF'
+			}
+		}
+		
+		hub.directCommand(self.id, cmd, timeout, function(error, status) {
+			if(error || status == null || typeof status == 'undefined' || typeof status.response == 'undefined'){
+				self.log("Error getting power state of " + self.name)
+				self.log.debug('Error: ' + util.inspect(error))
+	
+				if (typeof callback !== 'undefined') {
+					callback(error, null)
+					return
+				} else {
+					return
+				}
+			} else {					
+				if (status.success) {
+					self.currentState = true
+					self.service.getCharacteristic(Characteristic.On).updateValue(true)
+					self.lastUpdate = moment()
+					
+					if (typeof callback !== 'undefined') {
+						callback(null, self.currentState)
+						return
+					} else {
+						return
+					}       
+				} 
+			}
+		})
+	} else { //state = false = off
+		if(self.position == 'bottom') {	
+			cmd = {
+			  extended: true,
+			  cmd1: '13',
+			  cmd2: '00',
+			  userData: ['02'],
+			  isStandardResponse: true
+			}
+		} else {
+			cmd = {
+			  cmd1: '13',
+			  cmd2: '00'
+			}
+		}
+		
+		hub.directCommand(self.id, cmd, timeout, function(error, status) {
+			if(error || status == null || typeof status == 'undefined' || typeof status.response == 'undefined'){
+				self.log("Error getting power state of " + self.name)
+				self.log.debug('Error: ' + util.inspect(error))
+	
+				if (typeof callback !== 'undefined') {
+					callback(error, null)
+					return
+				} else {
+					return
+				}
+			} else {					
+				if (status.success) {
+					self.service.getCharacteristic(Characteristic.On).updateValue(false)
+					self.currentState = false
+					self.lastUpdate = moment()
+			
+					if (typeof callback !== 'undefined') {
+						callback(null, self.currentState)
+						return
+					} else {
+						return
+					}       
+				}
+			}
+		})         
+	}
+}
+
+InsteonLocalAccessory.prototype.getOutletState = function(callback) {
+    var self = this
+	
+	var timeout = 0
+	var cmd = {
+	  cmd1: '19',
+	  cmd2: '01'
+	}
+	
+	self.platform.checkHubConnection()
+	
+    self.log('Getting power state for ' + self.name)
+
+    hub.directCommand(self.id, cmd, timeout, function(error, status) {		
+		if(error || typeof status == 'undefined' || typeof status.response == 'undefined' || typeof status.response.standard == 'undefined' || status.success == false){
+			self.log("Error getting power state of " + self.name)
+			if (typeof callback !== 'undefined') {
+				callback(error, null)
+				return
+			} else {
+				return
+			}
+		}
+		
+		//self.log.debug('Outlet status: ' + util.inspect(status))
+		
+		if (status.success) {	
+			var command2 = status.response.standard.command2.substr(1,1) //0 = both off, 1 = top on, 2 = bottom on, 3 = both on
+			
+			switch (command2) {
+				case '0':
+					self.currentState = false
+				break
+			
+				case '1':
+					if(self.position =='bottom'){
+						self.currentState = false
+					} else {
+						self.currentState = true
+					}
+				break
+			
+				case '2':
+					if(self.position =='bottom'){
+						self.currentState = true
+					} else {
+						self.currentState = false
+					}
+				break
+			
+				case '3':
+					self.currentState = true
+				break
+			}
+			
+			self.log.debug(self.name + ' is ' + (self.currentState ? 'on' : 'off'))
+			self.service.getCharacteristic(Characteristic.On).updateValue(self.currentState)
+			self.lastUpdate = moment()
+			if (typeof callback !== 'undefined') {
+				callback(null, self.currentState)
+			} else {
+				return
+			}
+		}
+	})       
+}
+
+InsteonLocalAccessory.prototype.getPosition = function(callback) { //get position for shades/blinds
+    var self = this
+		
+	self.platform.checkHubConnection()
+	
+    self.log('Getting status for ' + self.name)
+
+    self.light.level(function(err,level) {
+		if(err || level == null || typeof level == 'undefined'){
+			self.log("Error getting power state of " + self.name)
+			if (typeof callback !== 'undefined') {
+				callback(null, self.level)
+			} else {
+				return
+			}
+			} else {	
+			
+			self.level = level
+			self.log.debug(self.name + ' is set to ' + level + '%')
+						
+			self.service.getCharacteristic(Characteristic.CurrentPosition).updateValue(self.level)
+			self.service.getCharacteristic(Characteristic.TargetPosition).updateValue(self.level)
+			self.lastUpdate = moment()
+			
+			if (typeof callback !== 'undefined') {
+				callback(null, self.level)
+			} else {
+				return
+			}
+		}
+	})       
+}
+
+InsteonLocalAccessory.prototype.setPosition = function(level, callback) { //get position for shades/blinds
+	var self = this
+	var oldLevel = self.level
+	
+	self.platform.checkHubConnection()
+	
+    hub.cancelPending(self.id)
+    
+    if (level > oldLevel){
+    	self.service.getCharacteristic(Characteristic.PositionState).updateValue(1)
+    } else {self.service.getCharacteristic(Characteristic.PositionState).updateValue(0)}
+    
+    self.log("Setting shades " + self.name + " to " + level + '%')
+    self.light.level(level).then(function(status)
+     {    
+        if (status.success) {                
+            self.level = level
+            self.service.getCharacteristic(Characteristic.CurrentPosition).updateValue(self.level)	
+			
+			self.log.debug(self.name + ' is at ' + level + '%')
+			self.lastUpdate = moment()
+			self.service.getCharacteristic(Characteristic.PositionState).updateValue(2)
+			if (typeof callback !== 'undefined') {
+				callback(null, self.level)
+			} else {
+				return
+			}	
+        } else {
+			self.log("Error setting level of " + self.name)   
+            if (typeof callback !== 'undefined') {
+                callback(error, null)
+                return
+            } else {
+                return
+            }
+		}
+	})       
+}
+
 function InsteonLocalAccessory(platform, device) {
     var self = this
 
@@ -1050,7 +1609,7 @@ InsteonLocalAccessory.prototype.init = function(platform, device) {
 
     self.platform = platform
     self.log = platform.log
-    self.id = device.deviceID
+    self.id = device.deviceID.toUpperCase()
     self.dimmable = (device.dimmable == "yes") ? true : false
     self.currentState = ''
     self.level = ''
@@ -1067,17 +1626,31 @@ InsteonLocalAccessory.prototype.init = function(platform, device) {
     	self.groupID = device.groupID
 		self.keypadbtn = device.keypadbtn
 		self.six_btn = device.six_btn
+		
+		if(typeof device.groupMembers !== 'undefined'){
+			var reg = /,|,\s/
+			self.groupMembers = device.groupMembers.split(reg)
+		}
 	}
     
     if (self.deviceType == 'iolinc') {
         self.gdo_delay = device.gdo_delay || 15
     }
     
+    if (self.deviceType == 'remote') {
+    	self.button = device.remotebtn
+    	self.stateless = device.stateless
+	}
+    
+    if (self.deviceType == 'outlet') {
+    	self.position = device.position || 'top'
+	}
+    
 	if(self.refreshInterval > 0){    
-		hub.on('connect',function(){		
-			if (self.deviceType == ('lightbulb' || 'dimmer' || 'switch' || 'iolinc' || 'scene'))
+		hub.once('connect',function(){		
+			if (self.deviceType == ('lightbulb' || 'dimmer' || 'switch' || 'iolinc' || 'scene' || 'outlet' || 'fan' || 'shades' || 'blinds'))
 			{
-				setTimeout(function(){self.pollStatus.call(self)},self.refreshInterval*1000)
+				setTimeout(function() {self.pollStatus.call(self)}, (1000 * self.refreshInterval))
 			} 
 		}	
 	)}	
@@ -1088,7 +1661,7 @@ InsteonLocalAccessory.prototype.getServices = function() {
     var services = []
     var infoService = new Service.AccessoryInformation()
     var deviceMAC = self.id.substr(0, 2) + '.' + self.id.substr(2, 2) + '.' + self.id.substr(4, 2)
-	
+
     infoService.setCharacteristic(Characteristic.Name, self.DeviceName)
     .setCharacteristic(Characteristic.Manufacturer, 'Insteon')
     .setCharacteristic(Characteristic.Model, 'Insteon')
@@ -1110,35 +1683,6 @@ InsteonLocalAccessory.prototype.getServices = function() {
 		
 		self.light = hub.light(self.id)
 		self.light.emitOnAck = true
-		
-		self.light.on('turnOn', function(group, level){
-			level = level || 100
-			self.log.debug(self.name + ' turned on to ' + level + '%')
-			self.service.getCharacteristic(Characteristic.On).updateValue(true)
-			if (self.dimmable) {
-				self.service.getCharacteristic(Characteristic.Brightness).updateValue(level)
-			}
-		})
-		
-		self.light.on('turnOff', function(){
-			self.log.debug(self.name + ' turned off')
-			self.service.getCharacteristic(Characteristic.On).updateValue(false)
-			if (self.dimmable) {
-				self.service.getCharacteristic(Characteristic.Brightness).updateValue(0)
-			}
-		})
-		
-		if (self.dimmable) {
-			self.light.on('brightened', function(){
-				self.log.debug(self.name + ' brightened')
-				self.getBrightnessLevel.call(self)
-			})
-		
-			self.light.on('dimmed', function(){
-				self.log.debug(self.name + ' dimmed')
-				self.getBrightnessLevel.call(self)
-			})
-		}
 		
 		//Get initial state
         hub.on('connect', function() {
@@ -1182,16 +1726,6 @@ InsteonLocalAccessory.prototype.getServices = function() {
 		self.light = hub.light(self.id)
 		self.light.emitOnAck = true
 		
-		self.light.on('turnOn', function(group, level){		
-			self.log.debug(self.name + ' turned on')
-			self.service.getCharacteristic(Characteristic.On).updateValue(true)
-		})
-		
-		self.light.on('turnOff', function(){
-			self.log.debug(self.name + ' turned off')
-			self.service.getCharacteristic(Characteristic.On).updateValue(false)
-		})
-		
         hub.on('connect', function() {
             self.getStatus.call(self)
         })
@@ -1230,7 +1764,7 @@ InsteonLocalAccessory.prototype.getServices = function() {
         	self.service.getCharacteristic(Characteristic.CurrentDoorState).updateValue(0)
 		})
 		
-        hub.on('connect', function() {
+        hub.once('connect', function() {
             self.getSensorStatus.call(self)
         })
 
@@ -1296,8 +1830,48 @@ InsteonLocalAccessory.prototype.getServices = function() {
         
         break    
         
+    case 'remote':
+        if (self.stateless) {
+        	self.service = new Service.StatelessProgrammableSwitch(self.name)
+        } else {
+        	self.service = new Service.Switch(self.name)
+        }
+        
+        self.dimmable = false
+        
+        break  
+        
+    case 'outlet':
+        self.service = new Service.Outlet(self.name)
+        self.service.getCharacteristic(Characteristic.OutletInUse).updateValue(true)
+        
+        self.service.getCharacteristic(Characteristic.On).on('set', self.setOutletState.bind(self))
+        
+        self.dimmable = false
+        
+        hub.once('connect', function() {
+            self.getOutletState.call(self)
+        })
+        
+        break  
+    
+    case 'shades':
+    case 'blinds':
+        self.service = new Service.WindowCovering(self.name)
+        self.service.getCharacteristic(Characteristic.PositionState).updateValue(2) //stopped       
+        
+        self.service.getCharacteristic(Characteristic.TargetPosition).on('set', self.setPosition.bind(self))
+        
+        self.light = hub.light(self.id)
+        
+        hub.once('connect', function() {
+            self.getPosition.call(self)
+        })
+        
+        break  
+    
     }
-
+	
     if (self.service) {
         services.push(self.service)
     }

--- a/index.js
+++ b/index.js
@@ -671,7 +671,7 @@ InsteonLocalAccessory.prototype.pollStatus = function() {
             self.pollStatus.call(self)
         }, 1000 * (self.refreshInterval - delta))
     } else {
-        console.log('Polling status for ' + self.name + '...')
+        self.log('Polling status for ' + self.name + '...')
 		
 		self.platform.checkHubConnection()
 		

--- a/index.js
+++ b/index.js
@@ -596,6 +596,28 @@ InsteonLocalPlatform.prototype.eventListener = function () {
 					}
 				}
 			}
+			
+			// find all the devices that the current event device is a contorller of
+			var responders = _.filter(self.devices, function(device){return _.contains(device.controllers,id,0)})
+
+			if (responders.length > 0) {
+				self.log.debug(id + " is a contoller of " + responders.length + " devices");
+
+				if(["11","12","13","14"].indexOf(command1) +1){ //only really care about on/off commands
+					
+					for (var i=0, l=responders.length; i < l; i++){
+
+						var responderDevice = accessories.filter(function(item) {
+							return (item.id == responders[i].deviceID)
+						})
+
+						responderDevice = responderDevice[0]
+						self.log('Getting status of responder device ' + responderDevice.name)
+						responderDevice.getStatus.call(responderDevice)
+
+					}
+				} else {self.log.debug("Ignoring Controller Command: " + command1)}
+			}
 		}
 	})
 }

--- a/index.js
+++ b/index.js
@@ -1077,7 +1077,7 @@ InsteonLocalAccessory.prototype.init = function(platform, device) {
 		hub.on('connect',function(){		
 			if (self.deviceType == ('lightbulb' || 'dimmer' || 'switch' || 'iolinc' || 'scene'))
 			{
-				self.pollStatus.call(self)
+				setTimeout(function(){self.pollStatus.call(self)},self.refreshInterval*1000)
 			} 
 		}	
 	)}	

--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ function InsteonLocalPlatform(log, config, api) {
     			connectedToHub = false
     			connectionWatcher()
     		},1000*self.keepAlive)
-    		if (connectedToHub == false && connectingToHub == false) {
+    		if (connectedToHub == false && connectingToHub != true) {
     			self.log('Reconnecting to Hub...')
     			connectToHub()
     		}
@@ -274,6 +274,8 @@ function InsteonLocalPlatform(log, config, api) {
 				var command2 = data.standard.command2
 
 				var isDevice = _.contains(deviceIDs, id, 0)
+
+				self.log.debug("Hub Command: " + info)
 
 				if (isDevice) {
 					var foundDevices = accessories.filter(function(item) {
@@ -416,7 +418,7 @@ InsteonLocalAccessory.prototype.pollStatus = function() {
             self.pollStatus.call(self)
         }, 1000 * (self.refreshInterval - delta))
     } else {
-        console.log('Polling status for ' + self.name + '...')
+        self.log('Polling status for ' + self.name + '...')
 
         switch (self.deviceType) {
         case 'lightbulb':
@@ -563,6 +565,7 @@ InsteonLocalAccessory.prototype.getPowerState = function(callback) {
 InsteonLocalAccessory.prototype.setBrightnessLevel = function(level, callback) {
     var self = this
 	
+	self.log.debug("Canceling Brightness Command For: " + self.name + self.id)
     hub.cancelPending(self.id)
     
     self.log("Setting level of " + self.name + " to " + level + '%')
@@ -948,6 +951,9 @@ InsteonLocalAccessory.prototype.setFanState = function(level, callback) {
     var self = this
 	var targetLevel
 	
+	self.log("Setting Fan of " + self.name + " to " + level + '%')
+	
+	self.log.debug("Canceling Fan Command For: " + self.name + self.deviceID)
     hub.cancelPending(self.id)
     
     if (level == 0){
@@ -1082,7 +1088,7 @@ InsteonLocalAccessory.prototype.getServices = function() {
     var services = []
     var infoService = new Service.AccessoryInformation()
     var deviceMAC = self.id.substr(0, 2) + '.' + self.id.substr(2, 2) + '.' + self.id.substr(4, 2)
-
+	
     infoService.setCharacteristic(Characteristic.Name, self.DeviceName)
     .setCharacteristic(Characteristic.Manufacturer, 'Insteon')
     .setCharacteristic(Characteristic.Model, 'Insteon')
@@ -1105,7 +1111,8 @@ InsteonLocalAccessory.prototype.getServices = function() {
 		self.light = hub.light(self.id)
 		self.light.emitOnAck = true
 		
-		self.light.on('turnOn', function(group, level){		
+		self.light.on('turnOn', function(group, level){
+			level = level || 100
 			self.log.debug(self.name + ' turned on to ' + level + '%')
 			self.service.getCharacteristic(Characteristic.On).updateValue(true)
 			if (self.dimmable) {
@@ -1176,7 +1183,7 @@ InsteonLocalAccessory.prototype.getServices = function() {
 		self.light.emitOnAck = true
 		
 		self.light.on('turnOn', function(group, level){		
-			self.log.debug(self.name + ' turned on to ' + level + ' %')
+			self.log.debug(self.name + ' turned on')
 			self.service.getCharacteristic(Characteristic.On).updateValue(true)
 		})
 		


### PR DESCRIPTION
@kuestess I experimented with adding support for some of my use cases, by allowing a device to 'listen' for events caused by another device and then update its status. In one of my cases I have 3 plug in dimmers that I want to control separately in HK but they are also controlled by a wall switch. So now when the wall switch is turned on the 3 plug in dimmers check their status so their state updates in HK. Before I would check the state of the PLDs every 5 minutes. It may be possible to use a scene, I just don't see the need of an "All Lamps" switch in HK.

Give it a look over - would like your input