### PR TITLE
Add Control for Targeted Keypad Button LEDs

### DIFF
--- a/index.js
+++ b/index.js
@@ -908,6 +908,31 @@ InsteonLocalAccessory.prototype.setPowerState = function(state, callback) {
 			self.currentState = true
 			self.lastUpdate = moment()
 
+			//Check if any target keypad button(s) to process
+			if(self.targetKeypadID.length > 0){
+				self.log.debug(self.targetKeypadID.length + ' target keypad(s) found for ' + self.name)
+
+				for(var temp = 0; temp < self.targetKeypadID.length; temp++){
+					self.log.debug(' targetKeypadID[' + temp + '] = ' + '[' + self.targetKeypadID[temp] + ']')
+				}
+
+				var count
+
+				for(count = 0; count < self.targetKeypadID.length; count++){
+					//self.log.debug('<Check point 0> count = ' + count)
+					
+					self.setTargetKeypadCount = count
+					run()
+
+					//Async-Wait function to insure multiple keypads are processed in order 
+					async function run() {
+				  		let promise = new Promise((resolve, reject) => self.setTargetKeypadBtn.call(self))
+				  		let result = await promise // wait until the promise resolves
+				  		return // "done!"
+					}
+				}
+			}
+
 			if (typeof callback !== 'undefined') {
 				callback(null, self.currentState)
 				return
@@ -933,6 +958,31 @@ InsteonLocalAccessory.prototype.setPowerState = function(state, callback) {
 			self.service.getCharacteristic(Characteristic.On).updateValue(false)
 			self.currentState = false
 			self.lastUpdate = moment()
+
+			//Check if any target keypad button(s) to process
+			if(self.targetKeypadID.length > 0){
+				self.log.debug(self.targetKeypadID.length + ' target keypad(s) found for ' + self.name)
+
+				for(var temp = 0; temp < self.targetKeypadID.length; temp++){
+					self.log.debug(' targetKeypadID[' + temp + '] = ' + '[' + self.targetKeypadID[temp] + ']')
+				}
+
+				var count
+
+				for(count = 0; count < self.targetKeypadID.length; count++){
+					//self.log.debug('<Check point 0> count = ' + count)
+					
+					self.setTargetKeypadCount = count
+					run()
+
+					//Async-Wait function to insure multiple keypads are processed in order 
+					async function run() {
+				  		let promise = new Promise((resolve, reject) => self.setTargetKeypadBtn.call(self))
+				  		let result = await promise // wait until the promise resolves
+				  		return // "done!"
+					}
+				}
+			}
 
 			if (typeof callback !== 'undefined') {
 				callback(null, self.currentState)
@@ -1086,7 +1136,8 @@ InsteonLocalAccessory.prototype.setBrightnessLevel = function(level, callback) {
 			self.log.debug(self.name + ' is ' + (self.currentState ? 'on' : 'off') + ' at ' + level + '%')
 			self.lastUpdate = moment()
 
-			if(self.targetKeypadID.length > 0){ // check if device has any target keypad(s) defined.
+			//Check if any target keypad button(s) to process
+			if(self.targetKeypadID.length > 0){
 				self.log.debug(self.targetKeypadID.length + ' target keypad(s) found for ' + self.name)
 
 				for(var temp = 0; temp < self.targetKeypadID.length; temp++){
@@ -2018,6 +2069,31 @@ InsteonLocalAccessory.prototype.setOutletState = function(state, callback) {
 					self.service.getCharacteristic(Characteristic.On).updateValue(true)
 					self.lastUpdate = moment()
 
+					//Check if any target keypad button(s) to process
+					if(self.targetKeypadID.length > 0){
+						self.log.debug(self.targetKeypadID.length + ' target keypad(s) found for ' + self.name)
+
+						for(var temp = 0; temp < self.targetKeypadID.length; temp++){
+							self.log.debug(' targetKeypadID[' + temp + '] = ' + '[' + self.targetKeypadID[temp] + ']')
+						}
+
+						var count
+
+						for(count = 0; count < self.targetKeypadID.length; count++){
+							//self.log.debug('<Check point 0> count = ' + count)
+							
+							self.setTargetKeypadCount = count
+							run()
+
+							//Async-Wait function to insure multiple keypads are processed in order 
+							async function run() {
+						  		let promise = new Promise((resolve, reject) => self.setTargetKeypadBtn.call(self))
+						  		let result = await promise // wait until the promise resolves
+						  		return // "done!"
+							}
+						}
+					}
+
 					if (typeof callback !== 'undefined') {
 						callback(null, self.currentState)
 						return
@@ -2059,6 +2135,31 @@ InsteonLocalAccessory.prototype.setOutletState = function(state, callback) {
 					self.service.getCharacteristic(Characteristic.On).updateValue(false)
 					self.currentState = false
 					self.lastUpdate = moment()
+
+					//Check if any target keypad button(s) to process
+					if(self.targetKeypadID.length > 0){
+						self.log.debug(self.targetKeypadID.length + ' target keypad(s) found for ' + self.name)
+
+						for(var temp = 0; temp < self.targetKeypadID.length; temp++){
+							self.log.debug(' targetKeypadID[' + temp + '] = ' + '[' + self.targetKeypadID[temp] + ']')
+						}
+
+						var count
+
+						for(count = 0; count < self.targetKeypadID.length; count++){
+							//self.log.debug('<Check point 0> count = ' + count)
+							
+							self.setTargetKeypadCount = count
+							run()
+
+							//Async-Wait function to insure multiple keypads are processed in order 
+							async function run() {
+						  		let promise = new Promise((resolve, reject) => self.setTargetKeypadBtn.call(self))
+						  		let result = await promise // wait until the promise resolves
+						  		return // "done!"
+							}
+						}
+					}			
 
 					if (typeof callback !== 'undefined') {
 						callback(null, self.currentState)

--- a/index.js
+++ b/index.js
@@ -1086,8 +1086,8 @@ InsteonLocalAccessory.prototype.setBrightnessLevel = function(level, callback) {
 			self.log.debug(self.name + ' is ' + (self.currentState ? 'on' : 'off') + ' at ' + level + '%')
 			self.lastUpdate = moment()
 
-			if(!self.linkedKeypadID == ''){ //Check if associated Keypad is configured
-				self.setLinkedKeypadBtn.call(self)
+			if(!self.targetKeypadID == ''){ //Check if associated Keypad is configured
+				self.setTargetKeypadBtn.call(self)
 				return
 			}
 			return
@@ -1608,7 +1608,7 @@ InsteonLocalAccessory.prototype.setKeypadState = function(state, callback) {
 	}
 }
 
-InsteonLocalAccessory.prototype.setLinkedKeypadBtn = function(state, callback) {
+InsteonLocalAccessory.prototype.setTargetKeypadBtn = function(state, callback) {
 	var self = this
 
 	var timeout = 0
@@ -1630,15 +1630,15 @@ InsteonLocalAccessory.prototype.setLinkedKeypadBtn = function(state, callback) {
 	}
 	var buttonArray
 
-	self.log('... also setting [Button ' + self.linkedKeypadBtn + '] of linked [Keypad ' + self.linkedKeypadID + '] to ' + self.currentState)
+	self.log('... also setting [Button ' + self.targetKeypadBtn + '] of target [Keypad ' + self.targetKeypadID + '] to ' + self.currentState)
 
 	self.platform.checkHubConnection()
 
 	getButtonMap(function(){
 		var currentButtonMap = self.buttonMap
 
-		self.six_btn = self.linkedKeypadSixBtn //can expand to support multiple devices using array
-		self.keypadbtn = self.linkedKeypadBtn //can expand to support multiple devices using array
+		self.six_btn = self.targetKeypadSixBtn //can expand to support multiple devices using array
+		self.keypadbtn = self.targetKeypadBtn //can expand to support multiple devices using array
 
 		if(self.six_btn == true){
 			buttonArray = six_buttonArray
@@ -1666,9 +1666,9 @@ InsteonLocalAccessory.prototype.setLinkedKeypadBtn = function(state, callback) {
 			isStandardResponse: true
 		}
 
-		hub.directCommand(self.linkedKeypadID, cmd, timeout, function(err,status){
+		hub.directCommand(self.targetKeypadID, cmd, timeout, function(err,status){
 			if(err || status == null || typeof status == 'undefined' || typeof status.response == 'undefined' || typeof status.response.standard == 'undefined' || status.success == false){
-				self.log('Error setting button state of linked keypad [' + self.linkedKeypadID + ']')
+				self.log('Error setting button state of target keypad [' + self.targetKeypadID + ']')
 				self.log.debug('Err: ' + util.inspect(err))
 
 				if (typeof callback !== 'undefined') {
@@ -1699,9 +1699,9 @@ InsteonLocalAccessory.prototype.setLinkedKeypadBtn = function(state, callback) {
 			cmd2: '01',
 		}
 
-		hub.directCommand(self.linkedKeypadID, command, timeout, function(err,status){
+		hub.directCommand(self.targetKeypadID, command, timeout, function(err,status){
 			if(err || status == null || typeof status == 'undefined' || typeof status.response == 'undefined' || typeof status.response.standard == 'undefined' || status.success == false){
-				self.log('Error getting button states for linked keypad ' + self.linkedKeypadID)
+				self.log('Error getting button states for target keypad ' + self.targetKeypadID)
 				self.log.debug('Err: ' + util.inspect(err))
 				return
 			} else {
@@ -2263,9 +2263,9 @@ InsteonLocalAccessory.prototype.init = function(platform, device) {
 	self.refreshInterval = device.refresh || platform.refreshInterval
 	self.server_port = platform.server_port
 	self.disabled = device.disabled || false
-	self.linkedKeypadID = device.linkedKeypadID || ''
-	self.linkedKeypadSixBtn = device.linkedKeypadSixBtn || true
-	self.linkedKeypadBtn = device.linkedKeypadBtn || ''
+	self.targetKeypadID = device.targetKeypadID || ''
+	self.targetKeypadSixBtn = device.targetKeypadSixBtn || true
+	self.targetKeypadBtn = device.targetKeypadBtn || ''
 	
 	if(self.id){
 		self.id = self.id.trim().replace(/\./g, '')

--- a/index.js
+++ b/index.js
@@ -1086,7 +1086,7 @@ InsteonLocalAccessory.prototype.setBrightnessLevel = function(level, callback) {
 			self.log.debug(self.name + ' is ' + (self.currentState ? 'on' : 'off') + ' at ' + level + '%')
 			self.lastUpdate = moment()
 
-			if(!self.targetKeypadID == ''){ //Check if associated Keypad is configured
+			if(!self.targetKeypadID == ''){
 				self.setTargetKeypadBtn.call(self)
 				return
 			}
@@ -1610,7 +1610,6 @@ InsteonLocalAccessory.prototype.setKeypadState = function(state, callback) {
 
 InsteonLocalAccessory.prototype.setTargetKeypadBtn = function(state, callback) {
 	var self = this
-
 	var timeout = 0
 	var eight_buttonArray = {
 		'A': 7,
@@ -1637,17 +1636,20 @@ InsteonLocalAccessory.prototype.setTargetKeypadBtn = function(state, callback) {
 	getButtonMap(function(){
 		var currentButtonMap = self.buttonMap
 
-		self.six_btn = self.targetKeypadSixBtn //can expand to support multiple devices using array
-		self.keypadbtn = self.targetKeypadBtn //can expand to support multiple devices using array
+		self.six_btn = self.targetKeypadSixBtn
+		self.keypadbtn = self.targetKeypadBtn
 
+		//self.log.debug('Six-button Keypad: ' + self.six_btn)
 		if(self.six_btn == true){
 			buttonArray = six_buttonArray
+			self.log.debug('Configured as 6-button Keypad')
 		} else {
 			buttonArray = eight_buttonArray
+			self.log.debug('Configured as 8-button Keypad')
 		}
 
 		var buttonNumber = buttonArray[self.keypadbtn]
-		self.log.debug('Six Button Keypad: ' + self.six_btn)
+		self.log.debug('Target button: ' + self.keypadbtn)
 		self.log.debug('Button number: ' + buttonNumber)
 		
 		var binaryButtonMap = currentButtonMap.substring(0,buttonNumber) +
@@ -2263,10 +2265,11 @@ InsteonLocalAccessory.prototype.init = function(platform, device) {
 	self.refreshInterval = device.refresh || platform.refreshInterval
 	self.server_port = platform.server_port
 	self.disabled = device.disabled || false
+
 	self.targetKeypadID = device.targetKeypadID || ''
-	self.targetKeypadSixBtn = device.targetKeypadSixBtn || true
+	self.targetKeypadSixBtn = device.targetKeypadSixBtn
 	self.targetKeypadBtn = device.targetKeypadBtn || ''
-	
+
 	if(self.id){
 		self.id = self.id.trim().replace(/\./g, '')
 	}


### PR DESCRIPTION
Added a method to handle setting/reseting specific LED button on targeted keypad device. Note, only the lighting of the LED is affected, not the actual scene/action that may be associated with that button. This method is desirable and more flexible than using `scene` control, which does not support dimming levels. 

Support is for `lightbulb` and `dimmer` devices for now. Only 1 set of targeted keypad/button per device can be specified at this time. Both limitations can easily be expanded later with some rework.

3 new parameters are introduced in config.json:

`"targetKeypadID": "<DeviceID>"` ... Device ID of the target keypad
`                    "targetKeypadSixBtn": "<true/false>"` ... "true" = 6-button keypad, "false" = 8-button keypad.
`                    "targetKeypadBtn": "<button>"` ... Button letter ("A" - "H") of the target keypad  

Sample config:
```
                {
                    "name": "Couch Light",
                    "deviceType": "lightbulb"
                    "deviceID": "3A65F8",
                    "dimmable": "yes",
                    "targetKeypadID": "4219FD",
                    "targetKeypadSixBtn": "true",
                    "targetKeypadBtn": "A"
                }
```
