### PR TITLE
Fix Garage Door 'No Response'

### DIFF
--- a/index.js
+++ b/index.js
@@ -2343,6 +2343,23 @@ InsteonLocalAccessory.prototype.getServices = function() {
 
 		break
 
+	case 'valve':
+		self.service = new Service.Valve(self.name)
+
+		self.service.getCharacteristic(Characteristic.Active).updateValue(0)
+		self.service.getCharacteristic(Characteristic.InUse).updateValue(0)
+		self.service.getCharacteristic(Characteristic.ValveType).updateValue(0)
+
+		self.service.getCharacteristic(Characteristic.Active).on('set', self.setRelayState.bind(self))
+
+		self.iolinc = hub.ioLinc(self.id)
+
+		hub.once('connect', function() {
+			self.getSensorStatus.call(self)
+		})
+
+		break
+
 	case 'leaksensor':
 		self.service = new Service.LeakSensor(self.name)
 		self.service.getCharacteristic(Characteristic.LeakDetected).updateValue(0) //Initialize as dry


### PR DESCRIPTION
It looked like the code was meant to only use sensor state emit to drive the HomeKit characteristic, but ended up also using an instance of getSensorStatus. I've made it so that is now 100% driven by sensor emits and effectively decoupled it from setRelayState, which now only has to worry about the relay itself. This is much cleaner IMHO.

Since Iolinc only supports 1 door sensor, only 1 door state can be trusted (Door fully open or Door fully closed). `gdo_delay` is only necessary for the interim door states (door is open-ing/clos-ing) and is applied according to `inverted_sensor` parameter.