### PR TITLE
Add 'momentary' property to scene config

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Scenes remain on/off only and support status when controlled via a Keypadlinc.  
   - `six_btn`: set to `true` if using a Keypadlinc configured as a 6-button; default is `false`
   - `groupID`: the group number in the Insteon app (Scenes->Edit Scene->Group Number)
   - `groupMembers`: comma-delimited list of Insteon IDs that are part of the group/scene (optional); member device status will be automatically updated after a scene is triggered
+  - `momentary`: since hub-based scenes do not support status, you can set this to `true` to make a scene 'stateless'. This will allow you to re-trigger the scene or run a different scene on the same devices without having to turn the scene `off` first. 
 
 Target Keypad LED:
 By Insteon's design, keypad (scene button) LED follows the state of a linked scene only; it does not act according to the device state itself. eg. Turn on `scene 1` then the corresponding keypad LED lights up, but turning on `Light 1` directly will not light up the keypad LED.

--- a/index.js
+++ b/index.js
@@ -1450,6 +1450,16 @@ InsteonLocalAccessory.prototype.setSceneState = function(state, callback) {
 
 				self.getGroupMemberStatus()
 
+        self.log.debug ('Scene is set to momentary: ' + self.momentary)
+				if (self.momentary) {
+					setTimeout(function(){
+						self.level = 0
+						self.service.getCharacteristic(Characteristic.On).updateValue(false)
+						self.currentState = false
+					},2000)
+				}
+
+
 				if (typeof callback !== 'undefined') {
 					callback(null)
 					return
@@ -2480,6 +2490,7 @@ InsteonLocalAccessory.prototype.init = function(platform, device) {
 		self.groupID = device.groupID
 		self.keypadbtn = device.keypadbtn
 		self.six_btn = device.six_btn
+		self.momentary = device.momentary || false
 
 		if(typeof device.groupMembers !== 'undefined'){
 			var reg = /,|,\s/


### PR DESCRIPTION
When set to true, the scene will trigger normally when set to ON, but
will show its status as OFF after 2000ms. This lets the user re-trigger
the scene or run another scene on the same responder devices without
having to turn the scene OFF first.