### PR TITLE
Expand groupMember support to on/off switches and dimmers

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Devices are also defined in the config.json as follows:
   - `targetKeypadBtn`: this is an array `["button_letter","button_letter"]` of Insteon keypad button(s), 'A' - 'H', that corresponds to the array from `targetKeypadID`. See additional notes below on Target Keypad LED.
   - `targetKeypadSixBtn`: this is an array `[true/false, true/false]` of Insteon keypad button layout, that corresponds to the array from `targetKeypadID`. `true` denote a 6-button keypad, while `false` denotes an 8-button keypad. See additional notes below on Target Keypad LED.
   - `disabled`: set to true to disable Insteon communication for a device (defaults to false).  Device will still appear in Home (or other apps), but can't be controlled.  Good to use for 'seasonal' devices.
+  - `groupMembers`: comma-delimited list of Insteon IDs that are linked to this device (optional, for devices with on/off states like dimmers and switches); member device status will be automatically updated after the device is turned on or off
 
 Battery operated devices: Battery status is monitored for battery operated devices (leak, motion, door/window sensors) and will alert when the device sends a low battery signal.  The heartbeat for those devices is also monitored (sent from device every 24 hours).  You will also receive a low battery alert if no heartbeat is received within 24 hours.
 

--- a/index.js
+++ b/index.js
@@ -530,6 +530,7 @@ InsteonLocalPlatform.prototype.eventListener = function () {
 							}
 
 							foundDevice.lastUpdate = moment()
+							foundDevice.getGroupMemberStatus.call(foundDevice)
 						}
 
 						if (command1 == 12) { //fast on
@@ -544,6 +545,7 @@ InsteonLocalPlatform.prototype.eventListener = function () {
 							foundDevice.service.getCharacteristic(Characteristic.On).updateValue(true)
 							foundDevice.currentState = true
 							foundDevice.lastUpdate = moment()
+							foundDevice.getGroupMemberStatus.call(foundDevice)
 						}
 
 						if (command1 == 13 || command1 == 14) { //13 = off, 14= fast off
@@ -558,6 +560,7 @@ InsteonLocalPlatform.prototype.eventListener = function () {
 							foundDevice.service.getCharacteristic(Characteristic.On).updateValue(false)
 							foundDevice.currentState = false
 							foundDevice.lastUpdate = moment()
+							foundDevice.getGroupMemberStatus.call(foundDevice)
 						}
 
 						if (command1 == 18) { //18 = stop changing
@@ -580,6 +583,7 @@ InsteonLocalPlatform.prototype.eventListener = function () {
 								foundDevice.lastUpdate = moment()
 								foundDevice.service.getCharacteristic(Characteristic.On).updateValue(true)
 								foundDevice.service.getCharacteristic(Characteristic.Brightness).updateValue(100)
+								foundDevice.getGroupMemberStatus.call(foundDevice)
 							}
 
 							if(commandedState == 13) {
@@ -588,6 +592,7 @@ InsteonLocalPlatform.prototype.eventListener = function () {
 								foundDevice.lastUpdate = moment()
 								foundDevice.service.getCharacteristic(Characteristic.On).updateValue(false)
 								foundDevice.service.getCharacteristic(Characteristic.Brightness).updateValue(0)
+								foundDevice.getGroupMemberStatus.call(foundDevice)
 							}
 						}
 
@@ -931,6 +936,8 @@ InsteonLocalAccessory.prototype.setPowerState = function(state, callback) {
 			self.currentState = true
 			self.lastUpdate = moment()
 
+			self.getGroupMemberStatus()
+			
 			//Check if any target keypad button(s) to process
 			if(self.targetKeypadID.length > 0){
 				self.log.debug(self.targetKeypadID.length + ' target keypad(s) found for ' + self.name)
@@ -982,6 +989,8 @@ InsteonLocalAccessory.prototype.setPowerState = function(state, callback) {
 			self.currentState = false
 			self.lastUpdate = moment()
 
+			self.getGroupMemberStatus()
+			
 			//Check if any target keypad button(s) to process
 			if(self.targetKeypadID.length > 0){
 				self.log.debug(self.targetKeypadID.length + ' target keypad(s) found for ' + self.name)
@@ -2464,7 +2473,12 @@ InsteonLocalAccessory.prototype.init = function(platform, device) {
 	self.targetKeypadSixBtn = device.targetKeypadSixBtn || []
 	self.targetKeypadBtn = device.targetKeypadBtn || []
 	self.setTargetKeypadCount = 0
-
+	
+	if(typeof device.groupMembers !== 'undefined'){
+		var reg = /,|,\s/
+		self.groupMembers = device.groupMembers.split(reg)
+	}
+	
 	if(self.id){
 		self.id = self.id.trim().replace(/\./g, '')
 	}
@@ -2480,12 +2494,8 @@ InsteonLocalAccessory.prototype.init = function(platform, device) {
 		self.groupID = device.groupID
 		self.keypadbtn = device.keypadbtn
 		self.six_btn = device.six_btn
-
-		if(typeof device.groupMembers !== 'undefined'){
-			var reg = /,|,\s/
-			self.groupMembers = device.groupMembers.split(reg)
-		}
-	}
+	
+  }
 
 	if (self.deviceType == 'keypad') {
 		self.keypadbtn = typeof(device.keypadbtn) === 'string' ? device.keypadbtn : '?'


### PR DESCRIPTION
This change allows users to add a groupMembers property to any device. This is useful for linked devices, like a wall switch, that acts as a controller for other devices.
