### PR TITLE
Homebridge 2.0 Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "engines": {
     "homebridge": ">=1.8.0 || >=2.0.0",
-    "node": ">=18"
+    "node": ">=20"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/kuestess/homebridge-platform-insteonlocal/issues"
   },
   "engines": {
-    "node": ">=12.13.0",
-    "homebridge": ">=1.3.0"
+    "homebridge": ">=1.8.0 || >=2.0.0",
+    "node": ">=18"
   },
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Did some quick smoke tests under HB 2.0, seems that everything is working without any changes. 🤞
Also bumped min supported Node version to 20+ as this is the now minimum support version for HB.